### PR TITLE
fix insecure TLS version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,6 @@ instructions.
 
 ## Status
 
-# * WARNING * WARNING * WARNING * WARNING *
-
-The API unfortunately uses an insecure and deprecated TLSv1 version. So use
-at your own risk. This also applies to their apps, hence please make sure you
-do not re-use any passwords, but create a unique one for this API.
-
-See: https://github.com/Tieske/millheat.lua/pull/1
-
-Once the problem is resolved:
-
- - update your unique password
- - re-request access tokens (here: https://api.millheat.com/ )
-
-# * WARNING * WARNING * WARNING * WARNING *
-
 Early development, session management works, all current methods implemented
 (that said; there are not that many methods unfortunately).
 

--- a/src/millheat/init.lua
+++ b/src/millheat/init.lua
@@ -93,10 +93,6 @@ local function mill_request(path, method, headers, query, body)
     headers = headers,
     source = ltn12.source.string(body or ""),
     sink = ltn12.sink.table(response_body),
-    -- TLS options
-    protocol = "any",
-    options  = {"all", "no_sslv2", "no_sslv3"},-- "no_tlsv1"},
-    verify   = "none",
   }
 --print(("="):rep(60))
 --print("Request: "..require("pl.pretty").write(r))


### PR DESCRIPTION
the current API implementation unfortunately only supports the insecure TLSv1 protocol.

Millheat support desk informed that it would probably be fixed tomorrow (10-Jan-2020). In anticipation this PR is here to rip out the insecure protocols once they updated.
